### PR TITLE
Add support for game Catalog, fixes #3

### DIFF
--- a/src/pitchdark.a
+++ b/src/pitchdark.a
@@ -37,6 +37,7 @@
          !source "src/ui.main.a"
          !source "src/ui.main.keys.a"
          !source "src/ui.options.a"
+         !source "src/ui.catalog.a"
          !source "src/ui.resume.a"
          !source "src/ui.versions.a"
          !source "src/ui.artwork.a"

--- a/src/ui.catalog.a
+++ b/src/ui.catalog.a
@@ -39,7 +39,7 @@ CatalogDialog
          txs
          jsr   HardResetWeeGUI
 
-         ldx   #WGClearScreen            ; paint background
+         ldx   #WGClearScreen        ; paint background
          jsr   WeeGUI
 
          jsr   CreateDialog          ; create decorated frame
@@ -57,11 +57,7 @@ CatalogDialog
          jsr   CreateButton          ; create 'main' button
          !word kViewCatalogMain
 
-         ldx   #WGViewPaintAll       ; paint UI controls (window frame, buttons, checkboxes, radio buttons)
-         jsr   WeeGUI
-
-         ldx   #WGSelectView         ; select frame (required for print routines that follow)
-         lda   #ID_CATALOG_FRAME
+         ldx   #WGViewPaintAll       ; paint UI controls (window frame, buttons)
          jsr   WeeGUI
 
          lda   gameCount
@@ -73,17 +69,15 @@ CatalogDialog
 
          lda   #0
          sta   startIndex
-         lda   #$FD                  ; reset previous start index just in case
-         sta   prevStartIndex
          jsr   RefreshCatalog
 
 ; WeeGUI cursor/key loop
          jsr   ClearPendingInput
--        ldx   #WGPendingClick
-         jsr   WeeGUI                ; check for mouse click
+-        ldx   #WGPendingClick       ; since our game list isn't WeeGUI buttons
+         jsr   WeeGUI                ; we need to manually check for mouse click
          cpx   #$FF
-         beq   @1
-         jsr   HandleCatalogClick
+         beq   @1                    ; no click
+         jsr   HandleCatalogClick    ; yes, mouse click
 @1       ldx   #WGPendingViewAction
          jsr   WeeGUI                ; handle mouse movement and clicks
          lda   $C000
@@ -97,22 +91,18 @@ CatalogDialog
 
 ;------------------------------------------------------------------------------
 RefreshCatalog
-         lda   startIndex
-         cmp   prevStartIndex       ; avoid redrawing the list if possible
-         beq   @noRefreshNeeded
-         sta   prevStartIndex
-         lda   #1
-         sta   lineNum
-         lda   #$C1                  ; letter 'A'
-         sta   kIndex + 1
-         ldx   #WGSelectView
+         lda   #ID_CATALOG_FRAME
+         ldx   #WGSelectView         ; select frame (required for print routines)
          jsr   WeeGUI
          ldx   #WGEraseViewContents
          jsr   WeeGUI
+         lda   #1                    ; start at second line within text frame
+         sta   catLineNum
+         lda   #$C1                  ; letter 'A', first game in game list
+         sta   kCatLetter + 1
          jsr   okvs_iter
          !word gGamesListStore
          !word printCatalog
-@noRefreshNeeded
          rts
 
 ;------------------------------------------------------------------------------
@@ -121,8 +111,6 @@ gameCount
          !byte $00                   ; SMC
 startIndex
          !byte $FD                   ; SMC
-prevStartIndex
-         !byte $FD                   ; SMC
 
 ; Count up the total number of games
 countGames
@@ -130,6 +118,42 @@ countGames
          rts
 
 ;------------------------------------------------------------------------------
+; Print out a single game name/letter, A/Y contains key, X contains index
+printCatalog
+         cpx   startIndex            ; skip until we reach our current start index
+         bcc   @skip
+         ldx   catLineNum
+         dex
+         cpx   #MAXGAMES             ; are we on the last line?
+         bcc   +
+@skip    rts
++        +STAY @key
+         jsr   okvs_get              ; retrieve the game name
+         !word gGamesListStore
+@key     !word $FDFD                 ; SMC
+         ldx   #55                   ; maximum string length
+         jsr   CreateNullTerminatedString ; copies string to kNullTerminatedBuffer
+         jsr   PrintAt
+         !byte 8
+catLineNum
+         !byte $FD                   ; SMC
+         !word kNullTerminatedBuffer
+         lda   catLineNum
+         sta   @ln2
+         jsr   PrintAt               ; print a letter key next to each game
+         !byte 4
+@ln2     !byte $FD                   ; SMC
+         !word kCatLetter
+        
+         inc   catLineNum
+         inc   kCatLetter + 1
+         rts
+
+kCatLetter
+         !text "[A]",0
+
+;------------------------------------------------------------------------------
+; User clicked on the screen, X, Y contain absolute mouse position
 HandleCatalogClick
          cpx   #8
          bcc   @outOfBounds
@@ -140,7 +164,7 @@ HandleCatalogClick
          tya
          clc
          adc   #$BF                 ; convert Y pos into 'A'-'Z' key
-         bra   isUpper
+         bra   isUppercaseKey       ; use our keyboard handler to verify
 @outOfBounds
          jmp   SoftBell
 
@@ -152,14 +176,14 @@ HandleCatalogClick
 ;------------------------------------------------------------------------------
 HandleCatalogKey
          cmp   #$E0
-         bcc   isUpper
+         bcc   isUppercaseKey
          and   #%11011111            ; convert lower to uppercase
-isUpper
+isUppercaseKey
          cmp   #$C1                  ; 'A'
          bcc   @notLetter
-         cmp   kIndex + 1
+         cmp   kCatLetter + 1        ; highest key (+1) on the game list
          bcs   @notLetter
-; we have an uppercase letter, convert to game index
+; convert uppercase letter to game index (+1)
          and   #%00011111
          clc
          adc   startIndex
@@ -167,7 +191,7 @@ isUpper
          dex
          jsr   loadNewGameInfoAndRepaint
 @main    jmp   MainScreen
-@notLetter
+@notLetter                           ; handle other (non-game) keys
          ldx   #(_endCatalogKeys-kCatalogKeys)-2
 -        cmp   kCatalogKeys,x
          beq   @activateView
@@ -208,40 +232,6 @@ catalog_previous
 
 catalog_main
          jmp   MainScreen
-
-;------------------------------------------------------------------------------
-; Print out a single game name, A/Y contains key, X contains index
-printCatalog
-         cpx   startIndex
-         bcc   @skip
-         ldx   lineNum
-         dex
-         cpx   #MAXGAMES
-         bcc   +
-@skip    rts
-+        +STAY @key
-         jsr   okvs_get
-         !word gGamesListStore
-@key     !word $FDFD                 ; SMC
-         ldx   #55                   ; maximum string length
-         jsr   CreateNullTerminatedString ; copies string to kNullTerminatedBuffer
-         jsr   PrintAt
-         !byte 8
-lineNum  !byte $FD                   ; SMC
-         !word kNullTerminatedBuffer
-         lda   lineNum
-         sta   @ln2
-         jsr   PrintAt
-         !byte 4
-@ln2     !byte $FD                   ; SMC
-         !word kIndex
-         inc   lineNum
-         inc   kIndex + 1
-         rts
-
-kIndex
-         !text "[A]",0
-
 
 ;------------------------------------------------------------------------------
 ; WeeGUI view configuration records

--- a/src/ui.catalog.a
+++ b/src/ui.catalog.a
@@ -1,0 +1,225 @@
+;license:MIT
+;(c) 2018 by 4am
+;
+; User interface - views and paint routines for catalog screen
+;
+; Public functions
+; - CatalogDialog
+;
+
+; View IDs (application-specific, acceptable range 0..15, no duplicates)
+ID_CATALOG_FRAME          = 1
+ID_CATALOG_OK             = 2
+ID_CATALOG_CANCEL         = 3
+ID_CATALOG_PREVIOUS       = 4
+ID_CATALOG_NEXT           = 5
+
+; action keys for catalog screen
+kCatalogKeys
+         !byte $8D,ID_CATALOG_OK                ; Return
+         !byte $9B,ID_CATALOG_CANCEL            ; Esc
+         !byte $88,ID_CATALOG_PREVIOUS          ; left arrow
+         !byte $8B,ID_CATALOG_PREVIOUS          ; up arrow
+         !byte $95,ID_CATALOG_NEXT              ; right arrow
+         !byte $8A,ID_CATALOG_NEXT              ; down arrow
+_endCatalogKeys
+
+MAXGAMES  =  20   ; max number of displayed games
+
+;------------------------------------------------------------------------------
+; CatalogDialog
+; call WeeGUI to create and paint option screen, and run to completion
+;
+; in:    WeeGUI initialized
+; out:   exits via MainScreen
+;        all registers and flags clobbered
+;------------------------------------------------------------------------------
+CatalogDialog
+         ldx   #$FF
+         txs
+         jsr   HardResetWeeGUI
+
+         jsr   CreateDialog          ; create decorated frame
+         !word kViewCatalogFrame
+         !word kStringCatalogFrame
+
+         ldx   #WGDesktop            ; paint background
+         jsr   WeeGUI
+
+         jsr   PaintTitleBar         ; paint top title bar
+
+         ldx   #WGViewPaintAll       ; paint UI controls (window frame, buttons, checkboxes, radio buttons)
+         jsr   WeeGUI
+
+         ldx   #WGSelectView         ; select frame (required for print routines that follow)
+         lda   #ID_CATALOG_FRAME
+         jsr   WeeGUI
+
+         lda   @gameCount
+         bne   @alreadyCounted
+         jsr   okvs_iter             ; count the total number of games
+         !word gGamesListStore
+         !word @countGames
+@alreadyCounted
+         lda   #$FD                  ; reset previous start index just in case
+         sta   @prevStartIndex
+         jsr   @RefreshCatalog
+
+; WeeGUI cursor/key loop
+         jsr   ClearPendingInput
+-        ldx   #WGPendingViewAction
+         jsr   WeeGUI                ; handle mouse movement and clicks
+         lda   $C000
+         bpl   -
+         jsr   ClearPendingInput
+         jsr   @HandleCatalogKey      ; handle keypresses
+         bra   -
+
+;------------------------------------------------------------------------------
+; internal functions
+;         !byte $01,$02,$03,$04,$05
+
+;------------------------------------------------------------------------------
+@RefreshCatalog
+         jsr   GetCurrentGameIndex
+         stx   @currGameIndex
+; Determine where to start in the game list
+         lda   #0
+         sta   @startIndex
+         sta   @lineNum
+         lda   @currGameIndex
+         cmp   #MAXGAMES/2           ; within MAXGAMES/2 of start?
+         bcc   @cont                 ; yes, start at top
+         clc
+         adc   #MAXGAMES/2
+         cmp   @gameCount            ; within MAXGAMES/2 of the end?
+         bcc   @1                    ; no
+         lda   @gameCount            ; yes, start at end
+@1       sec                         ; subtract off MAXGAMES
+         sbc   #MAXGAMES
+         sta   @startIndex
+
+@cont                                ; Print out the list of games
+         lda   @startIndex
+         cmp   @prevStartIndex       ; avoid redrawing the list if possible
+         beq   @noRefreshNeeded
+         sta   @prevStartIndex
+         jsr   okvs_iter
+         !word gGamesListStore
+         !word @printCatalog
+@noRefreshNeeded
+         jsr   @eraseOldCursor
+         jmp   @printCursor
+
+;------------------------------------------------------------------------------
+;         !byte $01,$02,$03,$04,$05
+@currGameIndex
+         !byte $FD                   ; SMC
+@gameCount
+         !byte $00                   ; SMC
+@startIndex
+         !byte $FD                   ; SMC
+@prevStartIndex
+         !byte $FD                   ; SMC
+
+; Count up the total number of games
+@countGames
+         inc   @gameCount
+         rts
+
+;------------------------------------------------------------------------------
+; Add an arrow cursor next to current game
+@printCursor
+         lda   @currGameIndex
+         sec
+         sbc   @startIndex
+         sta   @line1
+         jsr   PrintAt
+         !byte 1
+@line1   !byte $00                   ; SMC
+         !word @kStringCursor
+         rts
+@kStringCursor
+         !text "---->",0
+
+;------------------------------------------------------------------------------
+; Erase previous arrow cursor
+@eraseOldCursor
+         lda   @line1
+         sta   @line2
+         jsr   PrintAt
+         !byte 1
+@line2   !byte $FD                   ; SMC
+         !word @kStringErase
+@done
+         rts
+@kStringErase
+         !text "     ",0
+
+;------------------------------------------------------------------------------
+; Print out a single game name, A/Y contains key, X contains index
+@printCatalog
+         cpx   @startIndex
+         bcc   @skip
+         +STAY @key
+         jsr   okvs_get
+         !word gGamesListStore
+@key     !word $FDFD                 ; SMC
+         ldx   #55
+         jsr   CreateNullTerminatedString ; copies string to kNullTerminatedBuffer
+         jsr   PrintAt
+         !byte 6
+@lineNum !byte $FD                   ; SMC
+         !word kNullTerminatedBuffer
+         inc   @lineNum
+@skip    rts
+
+;------------------------------------------------------------------------------
+; HandleCatalog
+;
+; in:    A = key pressed
+; out:   all registers and flags clobbered
+;------------------------------------------------------------------------------
+@HandleCatalogKey
+         ldx   #(_endCatalogKeys-kCatalogKeys)-2
+-        cmp   kCatalogKeys,x
+         beq   @found
+         dex
+         dex
+         bpl   -
+         jmp   SoftBell
+@found   lda   kCatalogKeys+1,x
+         cmp   #ID_CATALOG_OK
+         beq   @callback_catalog_ok
+         cmp   #ID_CATALOG_CANCEL
+         beq   @callback_catalog_cancel
+         cmp   #ID_CATALOG_PREVIOUS
+         bne   @next
+         jsr   callback_previous
+         jmp   @RefreshCatalog
+@next    jsr   callback_next
+         jmp   @RefreshCatalog
+
+@callback_catalog_ok
+         jsr   SoftBell
+         jmp   MainScreen
+
+@callback_catalog_cancel
+         jmp   MainScreen
+
+
+;------------------------------------------------------------------------------
+; WeeGUI view configuration records
+
+kViewCatalogFrame
+         !byte ID_CATALOG_FRAME      ; view ID
+         !byte 0                     ; style (decorated frame)
+         !byte 4                     ; left
+         !byte 2                     ; top
+         !byte 72                    ; visible width
+         !byte 20                    ; visible height
+         !byte 72                    ; width
+         !byte 20                    ; height
+
+kStringCatalogFrame
+         !text "Catalog",0

--- a/src/ui.catalog.a
+++ b/src/ui.catalog.a
@@ -9,22 +9,22 @@
 
 ; View IDs (application-specific, acceptable range 0..15, no duplicates)
 ID_CATALOG_FRAME          = 1
-ID_CATALOG_OK             = 2
-ID_CATALOG_CANCEL         = 3
-ID_CATALOG_PREVIOUS       = 4
-ID_CATALOG_NEXT           = 5
+ID_CATALOG_MAIN           = 2
+ID_CATALOG_PREVIOUS       = 3
+ID_CATALOG_NEXT           = 4
 
 ; action keys for catalog screen
 kCatalogKeys
-         !byte $8D,ID_CATALOG_OK                ; Return
-         !byte $9B,ID_CATALOG_CANCEL            ; Esc
+         !byte $8D,ID_CATALOG_MAIN              ; <Return>
+         !byte $9B,ID_CATALOG_MAIN              ; <Esc>
          !byte $88,ID_CATALOG_PREVIOUS          ; left arrow
          !byte $8B,ID_CATALOG_PREVIOUS          ; up arrow
          !byte $95,ID_CATALOG_NEXT              ; right arrow
          !byte $8A,ID_CATALOG_NEXT              ; down arrow
+         !byte $A0,ID_CATALOG_NEXT              ; <Space>
 _endCatalogKeys
 
-MAXGAMES  =  20   ; max number of displayed games
+MAXGAMES  =  18   ; max number of displayed games
 
 ;------------------------------------------------------------------------------
 ; CatalogDialog
@@ -39,14 +39,23 @@ CatalogDialog
          txs
          jsr   HardResetWeeGUI
 
+         ldx   #WGClearScreen            ; paint background
+         jsr   WeeGUI
+
          jsr   CreateDialog          ; create decorated frame
          !word kViewCatalogFrame
          !word kStringCatalogFrame
 
-         ldx   #WGDesktop            ; paint background
-         jsr   WeeGUI
-
          jsr   PaintTitleBar         ; paint top title bar
+
+         jsr   CreateButton          ; create 'previous' button
+         !word kViewCatalogPrevious
+
+         jsr   CreateButton          ; create 'next' button
+         !word kViewCatalogNext
+
+         jsr   CreateButton          ; create 'main' button
+         !word kViewCatalogMain
 
          ldx   #WGViewPaintAll       ; paint UI controls (window frame, buttons, checkboxes, radio buttons)
          jsr   WeeGUI
@@ -55,167 +64,217 @@ CatalogDialog
          lda   #ID_CATALOG_FRAME
          jsr   WeeGUI
 
-         lda   @gameCount
+         lda   gameCount
          bne   @alreadyCounted
          jsr   okvs_iter             ; count the total number of games
          !word gGamesListStore
-         !word @countGames
+         !word countGames
 @alreadyCounted
+
+         lda   #0
+         sta   startIndex
          lda   #$FD                  ; reset previous start index just in case
-         sta   @prevStartIndex
-         jsr   @RefreshCatalog
+         sta   prevStartIndex
+         jsr   RefreshCatalog
 
 ; WeeGUI cursor/key loop
          jsr   ClearPendingInput
--        ldx   #WGPendingViewAction
+-        ldx   #WGPendingClick
+         jsr   WeeGUI                ; check for mouse click
+         cpx   #$FF
+         beq   @1
+         jsr   HandleCatalogClick
+@1       ldx   #WGPendingViewAction
          jsr   WeeGUI                ; handle mouse movement and clicks
          lda   $C000
          bpl   -
          jsr   ClearPendingInput
-         jsr   @HandleCatalogKey      ; handle keypresses
+         jsr   HandleCatalogKey      ; handle keypresses
          bra   -
 
 ;------------------------------------------------------------------------------
 ; internal functions
-;         !byte $01,$02,$03,$04,$05
 
 ;------------------------------------------------------------------------------
-@RefreshCatalog
-         jsr   GetCurrentGameIndex
-         stx   @currGameIndex
-; Determine where to start in the game list
-         lda   #0
-         sta   @startIndex
-         sta   @lineNum
-         lda   @currGameIndex
-         cmp   #MAXGAMES/2           ; within MAXGAMES/2 of start?
-         bcc   @cont                 ; yes, start at top
-         clc
-         adc   #MAXGAMES/2
-         cmp   @gameCount            ; within MAXGAMES/2 of the end?
-         bcc   @1                    ; no
-         lda   @gameCount            ; yes, start at end
-@1       sec                         ; subtract off MAXGAMES
-         sbc   #MAXGAMES
-         sta   @startIndex
-
-@cont                                ; Print out the list of games
-         lda   @startIndex
-         cmp   @prevStartIndex       ; avoid redrawing the list if possible
+RefreshCatalog
+         lda   startIndex
+         cmp   prevStartIndex       ; avoid redrawing the list if possible
          beq   @noRefreshNeeded
-         sta   @prevStartIndex
+         sta   prevStartIndex
+         lda   #1
+         sta   lineNum
+         lda   #$C1                  ; letter 'A'
+         sta   kIndex + 1
+         ldx   #WGSelectView
+         jsr   WeeGUI
+         ldx   #WGEraseViewContents
+         jsr   WeeGUI
          jsr   okvs_iter
          !word gGamesListStore
-         !word @printCatalog
+         !word printCatalog
 @noRefreshNeeded
-         jsr   @eraseOldCursor
-         jmp   @printCursor
+         rts
 
 ;------------------------------------------------------------------------------
 ;         !byte $01,$02,$03,$04,$05
-@currGameIndex
-         !byte $FD                   ; SMC
-@gameCount
+gameCount
          !byte $00                   ; SMC
-@startIndex
+startIndex
          !byte $FD                   ; SMC
-@prevStartIndex
+prevStartIndex
          !byte $FD                   ; SMC
 
 ; Count up the total number of games
-@countGames
-         inc   @gameCount
+countGames
+         inc   gameCount
          rts
 
 ;------------------------------------------------------------------------------
-; Add an arrow cursor next to current game
-@printCursor
-         lda   @currGameIndex
-         sec
-         sbc   @startIndex
-         sta   @line1
-         jsr   PrintAt
-         !byte 1
-@line1   !byte $00                   ; SMC
-         !word @kStringCursor
-         rts
-@kStringCursor
-         !text "---->",0
+HandleCatalogClick
+         cpx   #8
+         bcc   @outOfBounds
+         cpx   #68
+         bcs   @outOfBounds
+         cpy   #2
+         bcc   @outOfBounds
+         tya
+         clc
+         adc   #$BF                 ; convert Y pos into 'A'-'Z' key
+         bra   isUpper
+@outOfBounds
+         jmp   SoftBell
 
 ;------------------------------------------------------------------------------
-; Erase previous arrow cursor
-@eraseOldCursor
-         lda   @line1
-         sta   @line2
-         jsr   PrintAt
-         !byte 1
-@line2   !byte $FD                   ; SMC
-         !word @kStringErase
-@done
-         rts
-@kStringErase
-         !text "     ",0
-
-;------------------------------------------------------------------------------
-; Print out a single game name, A/Y contains key, X contains index
-@printCatalog
-         cpx   @startIndex
-         bcc   @skip
-         +STAY @key
-         jsr   okvs_get
-         !word gGamesListStore
-@key     !word $FDFD                 ; SMC
-         ldx   #55
-         jsr   CreateNullTerminatedString ; copies string to kNullTerminatedBuffer
-         jsr   PrintAt
-         !byte 6
-@lineNum !byte $FD                   ; SMC
-         !word kNullTerminatedBuffer
-         inc   @lineNum
-@skip    rts
-
-;------------------------------------------------------------------------------
-; HandleCatalog
+; HandleCatalogKey
 ;
 ; in:    A = key pressed
 ; out:   all registers and flags clobbered
 ;------------------------------------------------------------------------------
-@HandleCatalogKey
+HandleCatalogKey
+         cmp   #$E0
+         bcc   isUpper
+         and   #%11011111            ; convert lower to uppercase
+isUpper
+         cmp   #$C1                  ; 'A'
+         bcc   @notLetter
+         cmp   kIndex + 1
+         bcs   @notLetter
+; we have an uppercase letter, convert to game index
+         and   #%00011111
+         clc
+         adc   startIndex
+         tax
+         dex
+         jsr   loadNewGameInfoAndRepaint
+@main    jmp   MainScreen
+@notLetter
          ldx   #(_endCatalogKeys-kCatalogKeys)-2
 -        cmp   kCatalogKeys,x
-         beq   @found
+         beq   @activateView
          dex
          dex
          bpl   -
-         jmp   SoftBell
-@found   lda   kCatalogKeys+1,x
-         cmp   #ID_CATALOG_OK
-         beq   @callback_catalog_ok
-         cmp   #ID_CATALOG_CANCEL
-         beq   @callback_catalog_cancel
-         cmp   #ID_CATALOG_PREVIOUS
-         bne   @next
-         jsr   callback_previous
-         jmp   @RefreshCatalog
-@next    jsr   callback_next
-         jmp   @RefreshCatalog
+@error   jmp   SoftBell
 
-@callback_catalog_ok
-         jsr   SoftBell
+@activateView
+         lda   kCatalogKeys+1,x
+         tax
+         ldy   gViewInUse,x
+         beq   @error
+         ldx   #WGSelectView
+         jsr   WeeGUI
+@click   jmp   SimulateClick
+
+catalog_next
+         lda   startIndex
+         clc
+         adc   #MAXGAMES               ; page forward and refresh
+         cmp   gameCount
+         beq   @good
+         bcc   @good
+         jmp   SoftBell                ; at end of list
+@good    sta   startIndex
+         jmp   RefreshCatalog
+
+catalog_previous
+         lda   startIndex
+         bne   @1
+         jmp   SoftBell                ; at beginning of list
+@1
+         sec
+         sbc   #MAXGAMES               ; page back and refresh
+         sta   startIndex
+         jmp   RefreshCatalog
+
+catalog_main
          jmp   MainScreen
 
-@callback_catalog_cancel
-         jmp   MainScreen
+;------------------------------------------------------------------------------
+; Print out a single game name, A/Y contains key, X contains index
+printCatalog
+         cpx   startIndex
+         bcc   @skip
+         ldx   lineNum
+         dex
+         cpx   #MAXGAMES
+         bcc   +
+@skip    rts
++        +STAY @key
+         jsr   okvs_get
+         !word gGamesListStore
+@key     !word $FDFD                 ; SMC
+         ldx   #55                   ; maximum string length
+         jsr   CreateNullTerminatedString ; copies string to kNullTerminatedBuffer
+         jsr   PrintAt
+         !byte 8
+lineNum  !byte $FD                   ; SMC
+         !word kNullTerminatedBuffer
+         lda   lineNum
+         sta   @ln2
+         jsr   PrintAt
+         !byte 4
+@ln2     !byte $FD                   ; SMC
+         !word kIndex
+         inc   lineNum
+         inc   kIndex + 1
+         rts
+
+kIndex
+         !text "[A]",0
 
 
 ;------------------------------------------------------------------------------
 ; WeeGUI view configuration records
 
+kViewCatalogPrevious
+         !byte ID_CATALOG_PREVIOUS   ; view ID
+         !byte 1                     ; left
+         !byte 22                    ; top
+         !byte 13                    ; width
+         !word catalog_previous      ; callback
+         !word kStringCatPrevious    ; caption
+
+kViewCatalogNext
+         !byte ID_CATALOG_NEXT       ; view ID
+         !byte 66                    ; left
+         !byte 22                    ; top
+         !byte 13                    ; width
+         !word catalog_next          ; callback
+         !word kStringCatNext        ; caption
+
+kViewCatalogMain
+         !byte ID_CATALOG_MAIN       ; view ID
+         !byte 34                    ; left
+         !byte 22                    ; top
+         !byte 14                    ; width
+         !word catalog_main          ; callback
+         !word kStringCatMain        ; caption
+
 kViewCatalogFrame
          !byte ID_CATALOG_FRAME      ; view ID
          !byte 0                     ; style (decorated frame)
          !byte 4                     ; left
-         !byte 2                     ; top
+         !byte 1                     ; top
          !byte 72                    ; visible width
          !byte 20                    ; visible height
          !byte 72                    ; width
@@ -223,3 +282,12 @@ kViewCatalogFrame
 
 kStringCatalogFrame
          !text "Catalog",0
+
+kStringCatPrevious
+         !text "<--",0
+
+kStringCatNext
+         !text "-->",0
+
+kStringCatMain
+         !text "<ESC> Main",0

--- a/src/ui.main.a
+++ b/src/ui.main.a
@@ -21,6 +21,7 @@ ID_VERSIONS    = 7
 ID_INFO        = 8
 ID_DESCRIPTION = 9
 ID_ABOUT       = 10
+ID_CATALOG     = 11
 
 gMainScreenPaintDirty
          !byte 0
@@ -74,6 +75,9 @@ RepaintMainIfDirty
 
          jsr   CreateButton          ; create 'previous' button
          !word kViewPrevious
+
+         jsr   CreateButton          ; create 'catalog' button
+         !word kViewCatalog
 
          jsr   CreateButton          ; create 'settings' button
          !word kViewOptions
@@ -312,9 +316,17 @@ kViewNext
          !word callback_next         ; callback
          !word kStringNext           ; caption
 
+kViewCatalog
+         !byte ID_CATALOG            ; view ID
+         !byte 27                    ; left
+         !byte 2                     ; top
+         !byte 11                    ; width
+         !word CatalogDialog         ; callback
+         !word kStringCatalog
+
 kViewOptions
          !byte ID_OPTIONS            ; view ID
-         !byte 34                    ; left
+         !byte 41                    ; left
          !byte 2                     ; top
          !byte 12                    ; width
          !word OptionsDialog         ; callback
@@ -395,7 +407,9 @@ kStringPrevious
 kStringNext
          !byte $0E                   ; 'N' inverse
          !text "ext game >",0
-
+kStringCatalog
+         !byte $03                   ; 'C' inverse
+         !text "atalog",0
 kStringOptions
          !byte $13                   ; 'S' inverse
          !text "ettings",0

--- a/src/ui.main.keys.a
+++ b/src/ui.main.keys.a
@@ -28,6 +28,8 @@ kMainKeys
          !byte $E1,ID_BOXART         ; a
          !byte $D6,ID_VERSIONS       ; V
          !byte $F6,ID_VERSIONS       ; v
+         !byte $C3,ID_CATALOG        ; C
+         !byte $E3,ID_CATALOG        ; c
          !byte $D3,ID_OPTIONS        ; S
          !byte $F3,ID_OPTIONS        ; s
          !byte $D0,ID_PREVIOUS       ; P


### PR DESCRIPTION
Add support for game Catalog, fixes #3. You can use arrow keys to page thru the games, and use letter keys to select a particular game. Hitting <esc> goes back to the main screen.